### PR TITLE
Add testing for the extension

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": ["babel-preset-react"],
+  "plugins": [
+    ["transform-class-properties", {"spec": true}],
+    "transform-es2015-modules-commonjs",
+    "transform-object-rest-spread"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ yarn run webpack -- -w
 
 You will still have to reload the extension as above.
 
-
 To contribute a patch, fork this repository and send a pull request. I'd love to
 make this super useful for people.
 
@@ -69,3 +68,12 @@ make this super useful for people.
 [debugging]: about:debugging
 [nightly]: http://nightly.mozilla.org/
 [yarn]: https://github.com/yarnpkg/yarn
+
+
+## Testing
+
+Tests can be run with:
+
+```
+yarn run jest
+```

--- a/package.json
+++ b/package.json
@@ -8,16 +8,29 @@
   "license": "MIT",
   "devDependencies": {
     "babel-core": "^6.24.1",
+    "babel-jest": "^20.0.3",
     "babel-loader": "^7.0.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-react": "^6.24.1",
+    "enzyme": "^2.8.2",
     "file-loader": "^0.11.1",
+    "jest": "^20.0.3",
+    "jsdom": "^10.1.0",
+    "react-test-renderer": "^15.5.4",
+    "sinon-chrome": "^2.2.1",
     "webpack": "^2.5.1"
   },
   "dependencies": {
     "prop-types": "^15.5.10",
     "react": "^15.5.4",
     "react-dom": "^15.5.4"
+  },
+  "jest": {
+    "moduleDirectories": [
+      "./node_modules/",
+      "./src/js/"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "babel-core": "^6.24.1",
     "babel-loader": "^7.0.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-react": "^6.24.1",
     "file-loader": "^0.11.1",
     "webpack": "^2.5.1"

--- a/src/js/components/sidebar.jsx
+++ b/src/js/components/sidebar.jsx
@@ -1,6 +1,8 @@
 import PropTypes from "prop-types";
 import React from "react";
 
+import TabInfo from "components/tabInfo";
+
 export default class SideBar extends React.Component {
   state = {
     activeTabId: null,
@@ -44,9 +46,18 @@ export default class SideBar extends React.Component {
 
   render() {
     const { activeTabId, tabsById, tabIds } = this.state;
-    const tabs = tabIds.map(tabId =>
-      this._renderTab(tabId, activeTabId == tabId, tabsById.get(tabId)),
-    );
+    const tabs = tabIds.map(tabId => {
+      const tabInfo = tabsById.get(tabId);
+
+      return (
+        <TabInfo
+          key={tabInfo.id}
+          tabInfo={tabInfo}
+          onClick={this._onLIClicked.bind(this)}
+          onSelectionChanged={this._onSelectionChanged.bind(this)}}
+          />
+      );
+    });
 
     return (
       <div id="sidebar">
@@ -86,10 +97,11 @@ export default class SideBar extends React.Component {
     const { tabsById, tabIds } = this.state;
     tabsById.set(tab.id, {
       favIconUrl: tab.favIconUrl,
-      id: tab.id,
-      title: tab.title,
       // TODO: Fix this for when a filter is active
       filtered: false,
+      id: tab.id,
+      selected: false,
+      title: tab.title,
       url: tab.url,
     });
 
@@ -192,34 +204,6 @@ export default class SideBar extends React.Component {
     this.setState(Object.assign({}, this.state));
   }
 
-  _renderTab(tabId, isTabActive, { selected, title, favIconUrl, filtered }) {
-    const classes = [];
-
-    if (isTabActive) {
-      classes.push("active");
-    }
-
-    if (filtered) {
-      classes.push("filtered");
-    }
-
-    const liAttrs = { className: classes.join(" ") };
-
-    return (
-      <li {...liAttrs} key={tabId} onClick={e => this._onLIClicked(e, tabId)}>
-        <label>
-          <input
-            type="checkbox"
-            checked={selected}
-            onChange={e => this._onSelectionChanged(e, tabId)}
-          />
-          <img className="favicon" src={favIconUrl} />
-          {title}
-        </label>
-      </li>
-    );
-  }
-
   _getSelectedTabIds() {
     return Array
       .from(this.state.tabsById.values())
@@ -245,6 +229,6 @@ export default class SideBar extends React.Component {
   }
 }
 
-SideBar.PropTypes = {
-  windowId: PropTypes.number,
+SideBar.propTypes = {
+  windowId: PropTypes.number.isRequired,
 };

--- a/src/js/components/sidebar.jsx
+++ b/src/js/components/sidebar.jsx
@@ -182,7 +182,7 @@ export default class SideBar extends React.Component {
     const tabInfo = this.state.tabsById.get(tabId);
 
     let changed = false;
-    for (const key of ["favIconUrl", "title"]) {
+    for (const key of ["favIconUrl", "title", "url"]) {
       if (changeInfo.hasOwnProperty(key)) {
         changed = true;
         tabInfo[key] = changeInfo[key];

--- a/src/js/components/sidebar.jsx
+++ b/src/js/components/sidebar.jsx
@@ -267,37 +267,59 @@ export default class SideBar extends React.Component {
 
   _onFilterChanged(event) {
     const filter = event.target.value;
+    const { selectAll } = this.state;
+
+    const filteredTabs = this._filterTabs(filter);
+    const tabsById = this._selectAll(
+      filteredTabs,
+      selectAll,
+      this.state.tabsById,
+    );
 
     this.setState({
       ...this.state,
       filter,
-      filteredTabs: this._filterTabs(filter),
+      filteredTabs: filteredTabs,
+      tabsById,
     });
   }
 
   _toggleSelectAll(event) {
-    const { tabsById } = this.state;
+    const { filteredTabs, tabsById } = this.state;
     const selectAll = event.target.checked;
-    for (let [tabId, tab] of tabsById) {
-      tab.selected = !tab.filtered && selectAll;
-    }
 
     this.setState({
       ...this.state,
       selectAll,
+      tabsById: this._selectAll(filteredTabs, selectAll, tabsById),
     });
+  }
+
+  _selectAll(filteredTabs, selectAll, tabsById) {
+    const newTabsById = new Map(
+      Array.from(tabsById.entries()).map(([k, v]) => [
+        k,
+        Object.assign({}, v, { selected: !selectAll }),
+      ]),
+    );
+
+    for (const tabId of filteredTabs) {
+      newTabsById.get(tabId).selected = selectAll;
+    }
+
+    return newTabsById;
   }
 
   _getSelectedTabIds() {
     // prettier-ignore
     return Array
       .from(this.state.tabsById.values())
-      .reduce((acc, { id, selected }) => {
-        if (selected) {
-          acc.push(id);
+      .reduce((selectedTabs, { id, selected }) => {
+        if (selectedTabs) {
+          selectedTabs.push(id);
         }
 
-        return acc;
+        return selectedTabs;
       }, []);
   }
 

--- a/src/js/components/sidebar.jsx
+++ b/src/js/components/sidebar.jsx
@@ -183,7 +183,7 @@ export default class SideBar extends React.Component {
 
     let changed = false;
     for (const key of ["favIconUrl", "title"]) {
-      if (changeInfo[key]) {
+      if (changeInfo.hasOwnProperty(key)) {
         changed = true;
         tabInfo[key] = changeInfo[key];
       }

--- a/src/js/components/sidebar.jsx
+++ b/src/js/components/sidebar.jsx
@@ -6,6 +6,7 @@ import TabInfo from "components/tabInfo";
 export default class SideBar extends React.Component {
   state = {
     activeTabId: null,
+    selectAll: false,
     tabsBydId: new Map(),
     tabIds: [],
   };
@@ -26,6 +27,7 @@ export default class SideBar extends React.Component {
     this._onSelectionChanged = this._onSelectionChanged.bind(this);
     this._onTabInfoClicked = this._onTabInfoClicked.bind(this);
 
+    this._toggleSelectAll = this._toggleSelectAll.bind(this);
     this._gatherSelected = this._gatherSelected.bind(this);
     this._closeSelected = this._closeSelected.bind(this);
   }
@@ -73,7 +75,7 @@ export default class SideBar extends React.Component {
   }
 
   render() {
-    const { activeTabId, tabsById, tabIds } = this.state;
+    const { activeTabId, selectAll, tabsById, tabIds } = this.state;
     const tabs = tabIds.map(tabId => {
       const tabInfo = tabsById.get(tabId);
 
@@ -104,11 +106,12 @@ export default class SideBar extends React.Component {
             placeholder="Filter tabs…"
             onChange={e => this._filterChanged(e)}
           />
-          <label className="block" htmlFor="select-all">
+          <label className="block">
             <input
               id="select-all"
               type="checkbox"
-              onChange={e => this._toggleSelectAll(e)}
+              checked={selectAll}
+              onChange={this._toggleSelectAll}
             />
             Select all tabs
           </label>
@@ -195,10 +198,12 @@ export default class SideBar extends React.Component {
   }
 
   _onSelectionChanged(event, tabId) {
-    const { tabsById } = this.state;
+    const { selectAll, tabsById } = this.state;
     tabsById.get(tabId).selected = event.target.checked;
 
-    this.setState(Object.assign({}, this.state));
+    this.setState(
+      selectAll ? {...this.state, selectAll: false} : {...this.state}
+    );
   }
 
   _onTabInfoClicked(event, tabId) {
@@ -235,11 +240,15 @@ export default class SideBar extends React.Component {
 
   _toggleSelectAll(event) {
     const { tabsById } = this.state;
+    const selectAll = event.target.checked;
     for (let [tabId, tab] of tabsById) {
-      tab.selected = !tab.filtered && event.target.checked;
+      tab.selected = !tab.filtered && selectAll;
     }
 
-    this.setState(Object.assign({}, this.state));
+    this.setState({
+      ...this.state,
+      selectAll,
+    });
   }
 
   _getSelectedTabIds() {

--- a/src/js/components/sidebar.jsx
+++ b/src/js/components/sidebar.jsx
@@ -52,9 +52,10 @@ export default class SideBar extends React.Component {
       return (
         <TabInfo
           key={tabInfo.id}
+          active={activeTabId === tabId}
           tabInfo={tabInfo}
           onClick={this._onLIClicked.bind(this)}
-          onSelectionChanged={this._onSelectionChanged.bind(this)}}
+          onSelectionChanged={this._onSelectionChanged.bind(this)}
           />
       );
     });

--- a/src/js/components/tabInfo.jsx
+++ b/src/js/components/tabInfo.jsx
@@ -1,0 +1,51 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+/**
+ * Render information about a tab.
+ *
+ * This will render the controls for selecting that tab and render the metadata
+ * for the tab as well.
+ */
+const TabInfo = function TabInfo({ onClick, onSelectionChanged, tabInfo }) {
+  const { active, favIconUrl, filtered, id, selected, title } = tabInfo;
+
+  const classes = [];
+
+  if (active) {
+    classes.push("active");
+  }
+
+  if (filtered) {
+    classes.push("filtered");
+  }
+
+  return (
+    <li className={classes.join(" ")} onClick={e => onClick(e, id)}>
+      <label>
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={e => onSelectionChanged(e, id)}
+        />
+        <img className="favicon" src={favIconUrl} />
+        {title}
+      </label>
+    </li>
+  );
+};
+
+TabInfo.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  onSelectionChanged: PropTypes.func.isRequired,
+  tabInfo: PropTypes.shape({
+    active: PropTypes.bool.isRequired,
+    favIconUrl: PropTypes.string,
+    filtered: PropTypes.bool.isRequired,
+    id: PropTypes.number.isRequired,
+    selected: PropTypes.bool.isRequired,
+    title: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default TabInfo;

--- a/src/js/components/tabInfo.jsx
+++ b/src/js/components/tabInfo.jsx
@@ -9,20 +9,12 @@ import React from "react";
  */
 const TabInfo = function TabInfo(props) {
   const { active, onClick, onSelectionChanged, tabInfo } = props;
-  const { favIconUrl, filtered, id, selected, title } = tabInfo;
+  const { favIconUrl, id, selected, title } = tabInfo;
 
-  const classes = [];
-
-  if (active) {
-    classes.push("active");
-  }
-
-  if (filtered) {
-    classes.push("filtered");
-  }
+  const className = active ? "active" : null;
 
   return (
-    <li className={classes.join(" ")} onClick={e => onClick(e, id)}>
+    <li className={className} onClick={e => onClick(e, id)}>
       <label>
         <input
           type="checkbox"
@@ -42,7 +34,6 @@ TabInfo.propTypes = {
   onSelectionChanged: PropTypes.func.isRequired,
   tabInfo: PropTypes.shape({
     favIconUrl: PropTypes.string,
-    filtered: PropTypes.bool.isRequired,
     id: PropTypes.number.isRequired,
     selected: PropTypes.bool.isRequired,
     title: PropTypes.string.isRequired,

--- a/src/js/components/tabInfo.jsx
+++ b/src/js/components/tabInfo.jsx
@@ -7,8 +7,9 @@ import React from "react";
  * This will render the controls for selecting that tab and render the metadata
  * for the tab as well.
  */
-const TabInfo = function TabInfo({ onClick, onSelectionChanged, tabInfo }) {
-  const { active, favIconUrl, filtered, id, selected, title } = tabInfo;
+const TabInfo = function TabInfo(props) {
+  const { active, onClick, onSelectionChanged, tabInfo } = props;
+  const { favIconUrl, filtered, id, selected, title } = tabInfo;
 
   const classes = [];
 
@@ -36,10 +37,10 @@ const TabInfo = function TabInfo({ onClick, onSelectionChanged, tabInfo }) {
 };
 
 TabInfo.propTypes = {
+  active: PropTypes.bool.isRequired,
   onClick: PropTypes.func.isRequired,
   onSelectionChanged: PropTypes.func.isRequired,
   tabInfo: PropTypes.shape({
-    active: PropTypes.bool.isRequired,
     favIconUrl: PropTypes.string,
     filtered: PropTypes.bool.isRequired,
     id: PropTypes.number.isRequired,

--- a/src/sidebar.css
+++ b/src/sidebar.css
@@ -49,8 +49,3 @@ body {
 li.active > label {
   font-weight: bold;
 }
-
-.hidden,
-.filtered {
-  display: none;
-}

--- a/test/components/sidebar.test.jsx
+++ b/test/components/sidebar.test.jsx
@@ -146,4 +146,34 @@ describe("<SideBar /> with multiple tabs", () => {
       }
     });
   });
+
+  test("removing tabs", done => {
+    const sidebar = mount(<SideBar windowId={testWindowId} />);
+
+    setTimeout(() => {
+      try {
+        expect(browser.windows.get.called).toBe(true);
+
+        browser.tabs.onRemoved.trigger(testTabs[1].id, {
+          windowId: testWindowId,
+          isWindowClsoing: false,
+        });
+
+        expect(sidebar.state().tabIds).toEqual([
+          testTabs[0].id,
+          testTabs[2].id
+        ]);
+
+        const tabs = sidebar.find(TabInfo);
+
+        expect(tabs.length).toBe(2);
+        expect(tabs.at(0).props().tabInfo.id).toBe(testTabs[0].id);
+        expect(tabs.at(1).props().tabInfo.id).toBe(testTabs[2].id);
+
+        done();
+      } catch (e) {
+        done.fail(e);
+      }
+    });
+  });
 });

--- a/test/components/sidebar.test.jsx
+++ b/test/components/sidebar.test.jsx
@@ -1,4 +1,5 @@
-import "../dom.js";
+import "../dom";
+import { defer } from "../util";
 
 import { mount } from "enzyme";
 import React from "react";
@@ -7,29 +8,25 @@ import browser from "sinon-chrome";
 import SideBar from "components/sidebar";
 import TabInfo from "components/tabInfo";
 
-afterEach(() => browser.reset());
-
 const testWindowId = 123;
 
-test("<SideBar /> with 0 tabs", done => {
-  browser.windows.get.withArgs(testWindowId, { populate: true }).returns(
-    new Promise(resolve =>
-      resolve({
-        tabs: [],
-      }),
-    ),
-  );
+afterEach(() => browser.reset());
 
-  const sidebar = mount(<SideBar windowId={testWindowId} />);
+describe("<SideBar /> with no tabs", () => {
+  let sidebar;
 
-  setTimeout(() => {
-    try {
-      expect(browser.windows.get.called).toBe(true);
-      expect(sidebar.find("#tabs-list").children().length).toEqual(0);
-      done();
-    } catch (e) {
-      done.fail(e);
-    }
+  beforeEach(async done => {
+    browser.windows.get
+      .withArgs(testWindowId, { populate: true })
+      .returns(new Promise(resolve => resolve({ tabs: [] })));
+
+    sidebar = mount(<SideBar windowId={testWindowId} />);
+    await defer().then(done);
+  });
+
+  test("rendering", () => {
+    expect(browser.windows.get.called).toBe(true);
+    expect(sidebar.find("#tabs-list").children().length).toEqual(0);
   });
 });
 
@@ -57,172 +54,130 @@ describe("<SideBar /> with multiple tabs", () => {
     },
   ];
 
-  beforeEach(() => {
+  let sidebar;
+
+  beforeEach(async done => {
+    const tabsCopy = testTabs.map(obj => ({ ...obj }));
     browser.windows.get
       .withArgs(123, { populate: true })
-      .returns(new Promise(resolve => resolve({ tabs: testTabs.slice() })));
+      .returns(new Promise(resolve => resolve({ tabs: tabsCopy })));
+
+    sidebar = mount(<SideBar windowId={testWindowId} />);
+    await defer().then(done);
   });
 
-  test("rendering", done => {
-    const sidebar = mount(<SideBar windowId={testWindowId} />);
+  afterEach(() => (sidebar = undefined));
 
-    setTimeout(() => {
-      try {
-        expect(browser.windows.get.called).toBe(true);
-        expect(sidebar.find("#tabs-list").children().length).toEqual(
-          testTabs.length,
-        );
-        done();
-      } catch (e) {
-        done.fail(e);
-      }
-    });
+  test("rendering", () => {
+    expect(browser.windows.get.called).toBe(true);
+    expect(sidebar.find("#tabs-list").children().length).toEqual(
+      testTabs.length,
+    );
   });
 
-  test("moving tabs", done => {
-    const sidebar = mount(<SideBar windowId={testWindowId} />);
+  test("moving tabs", () => {
+    expect(browser.windows.get.called).toBe(true);
 
-    setTimeout(() => {
-      try {
-        expect(browser.windows.get.called).toBe(true);
-
-        browser.tabs.onMoved.trigger(testTabs[0].id, {
-          windowId: testWindowId,
-          fromIndex: 0,
-          toIndex: 2,
-        });
-
-        expect(sidebar.state().tabIds).toEqual([
-          testTabs[1].id,
-          testTabs[2].id,
-          testTabs[0].id,
-        ]);
-
-        const tabs = sidebar.find(TabInfo);
-
-        expect(tabs.length).toBe(3);
-        expect(tabs.at(0).props().tabInfo.id).toBe(testTabs[1].id);
-        expect(tabs.at(1).props().tabInfo.id).toBe(testTabs[2].id);
-        expect(tabs.at(2).props().tabInfo.id).toBe(testTabs[0].id);
-
-        done();
-      } catch (e) {
-        done.fail(e);
-      }
+    browser.tabs.onMoved.trigger(testTabs[0].id, {
+      windowId: testWindowId,
+      fromIndex: 0,
+      toIndex: 2,
     });
+
+    expect(sidebar.state().tabIds).toEqual([
+      testTabs[1].id,
+      testTabs[2].id,
+      testTabs[0].id,
+    ]);
+
+    const tabs = sidebar.find(TabInfo);
+    expect(tabs.length).toBe(3);
+    expect(tabs.at(0).props().tabInfo.id).toBe(testTabs[1].id);
+    expect(tabs.at(1).props().tabInfo.id).toBe(testTabs[2].id);
+    expect(tabs.at(2).props().tabInfo.id).toBe(testTabs[0].id);
   });
 
-  test("creating tabs", done => {
-    const sidebar = mount(<SideBar windowId={testWindowId} />);
+  test("creating tabs", () => {
+    expect(browser.windows.get.called).toBe(true);
 
-    setTimeout(() => {
-      try {
-        expect(browser.windows.get.called).toBe(true);
-
-        browser.tabs.onCreated.trigger({
-          favIconUrl: "http://example.com/baz.ico",
-          id: 4,
-          title: "example.com/baz",
-          url: "http://example.com/baz",
-          windowId: testWindowId,
-          index: 3,
-        });
-
-        expect(sidebar.state().tabIds).toEqual([
-          testTabs[0].id,
-          testTabs[1].id,
-          testTabs[2].id,
-          4,
-        ]);
-
-        const tabs = sidebar.find(TabInfo);
-
-        expect(tabs.length).toBe(4);
-        expect(tabs.at(0).props().tabInfo.id).toBe(testTabs[0].id);
-        expect(tabs.at(1).props().tabInfo.id).toBe(testTabs[1].id);
-        expect(tabs.at(2).props().tabInfo.id).toBe(testTabs[2].id);
-        expect(tabs.at(3).props().tabInfo.id).toBe(4);
-
-        done();
-      } catch (e) {
-        done.fail(e);
-      }
+    browser.tabs.onCreated.trigger({
+      favIconUrl: "http://example.com/baz.ico",
+      id: 4,
+      title: "example.com/baz",
+      url: "http://example.com/baz",
+      windowId: testWindowId,
+      index: 3,
     });
+
+    expect(sidebar.state().tabIds).toEqual([
+      testTabs[0].id,
+      testTabs[1].id,
+      testTabs[2].id,
+      4,
+    ]);
+
+    const tabs = sidebar.find(TabInfo);
+
+    expect(tabs.length).toBe(4);
+    expect(tabs.at(0).props().tabInfo.id).toBe(testTabs[0].id);
+    expect(tabs.at(1).props().tabInfo.id).toBe(testTabs[1].id);
+    expect(tabs.at(2).props().tabInfo.id).toBe(testTabs[2].id);
+    expect(tabs.at(3).props().tabInfo.id).toBe(4);
   });
 
-  test("removing tabs", done => {
-    const sidebar = mount(<SideBar windowId={testWindowId} />);
+  test("removing tabs", () => {
+    expect(browser.windows.get.called).toBe(true);
 
-    setTimeout(() => {
-      try {
-        expect(browser.windows.get.called).toBe(true);
-
-        browser.tabs.onRemoved.trigger(testTabs[1].id, {
-          windowId: testWindowId,
-          isWindowClsoing: false,
-        });
-
-        expect(sidebar.state().tabIds).toEqual([
-          testTabs[0].id,
-          testTabs[2].id,
-        ]);
-
-        const tabs = sidebar.find(TabInfo);
-
-        expect(tabs.length).toBe(2);
-        expect(tabs.at(0).props().tabInfo.id).toBe(testTabs[0].id);
-        expect(tabs.at(1).props().tabInfo.id).toBe(testTabs[2].id);
-
-        done();
-      } catch (e) {
-        done.fail(e);
-      }
+    browser.tabs.onRemoved.trigger(testTabs[1].id, {
+      windowId: testWindowId,
+      isWindowClsoing: false,
     });
+
+    expect(sidebar.state().tabIds).toEqual([testTabs[0].id, testTabs[2].id]);
+
+    const tabs = sidebar.find(TabInfo);
+    expect(tabs.length).toBe(2);
+    expect(tabs.at(0).props().tabInfo.id).toBe(testTabs[0].id);
+    expect(tabs.at(1).props().tabInfo.id).toBe(testTabs[2].id);
   });
 
-  test("updating tabs", done => {
-    const sidebar = mount(<SideBar windowId={testWindowId} />);
+  test("updating tabs", () => {
+    expect(browser.windows.get.called).toBe(true);
 
-    setTimeout(() => {
-      try {
-        expect(browser.windows.get.called).toBe(true);
-        
-        const tabs = sidebar.find(TabInfo);
+    const tabs = sidebar.find(TabInfo);
+    expect(tabs.at(0).props().tabInfo.favIconUrl).toBe(undefined);
+    expect(tabs.at(1).props().tabInfo.favIconUrl).toBe(testTabs[1].favIconUrl);
 
-        browser.tabs.onUpdated.trigger(
-          testTabs[0].id,
-          { favIconUrl: "http://example.com/favicon.ico" },
-          testTabs[0],
-        );
+    browser.tabs.onUpdated.trigger(
+      testTabs[0].id,
+      { favIconUrl: "http://example.com/favicon.ico" },
+      testTabs[0],
+    );
 
-        expect(sidebar.state().tabsById.get(testTabs[0].id).favIconUrl).toEqual(
-          "http://example.com/favicon.ico",
-        );
+    expect(sidebar.state().tabsById.get(testTabs[0].id).favIconUrl).toEqual(
+      "http://example.com/favicon.ico",
+    );
 
-        expect(tabs.at(0).props().tabInfo.favIconUrl).toEqual("http://example.com/favicon.ico");;
-        
-        browser.tabs.onUpdated.trigger(
-          testTabs[1].id,
-          {
-            title: "foo bar baz",
-            url: "http://example.com/foobarbaz",
-            favIconUrl: undefined,
-          },
-          testTabs[1],
-        );
+    expect(tabs.at(0).props().tabInfo.favIconUrl).toBe(
+      "http://example.com/favicon.ico",
+    );
 
-        expect(tabs.at(1).props().tabInfo.favIconUrl).toEqual(undefined);
-        const tabInfo = sidebar.state().tabsById.get(testTabs[1].id);
+    browser.tabs.onUpdated.trigger(
+      testTabs[1].id,
+      {
+        title: "foo bar baz",
+        url: "http://example.com/foobarbaz",
+        favIconUrl: undefined,
+      },
+      testTabs[1],
+    );
 
-        expect(tabInfo.title).toEqual("foo bar baz");
-        expect(tabInfo.hasOwnProperty("favIconUrl")).toBe(true);
-        expect(tabInfo.favIconUrl).toEqual(undefined);
-        expect(tabInfo.url).toEqual("http://example.com/foobarbaz");
+    expect(tabs.at(1).props().tabInfo.favIconUrl).toEqual(undefined);
 
-        done();
-      } catch (e) {
-        done.fail(e);
-      }
-    });
+    const tabInfo = sidebar.state().tabsById.get(testTabs[1].id);
+    expect(tabInfo.title).toEqual("foo bar baz");
+    expect(tabInfo.hasOwnProperty("favIconUrl")).toBe(true);
+    expect(tabInfo.favIconUrl).toEqual(undefined);
+    expect(tabInfo.url).toEqual("http://example.com/foobarbaz");
   });
 });

--- a/test/components/sidebar.test.jsx
+++ b/test/components/sidebar.test.jsx
@@ -260,5 +260,57 @@ describe("<SideBar /> with multiple tabs", () => {
 
     filter.simulate("change", { target: { value: "" } });
     expect(sidebar.find(TabInfo).length).toBe(4);
-  })
+  });
+
+  test("changing filter with select all", () => {
+    const filter = sidebar.find("#filter");
+    const selectAll = sidebar.find("#select-all");
+
+    filter.simulate("change", { target: { value: "nope" } });
+    expect(sidebar.find(TabInfo).exists()).toBe(false);
+
+    selectAll.simulate("change", { target: { checked: true } });
+    expect(sidebar.find(TabInfo).exists()).toBe(false);
+
+    filter.simulate("change", { target: { value: "" } });
+    let tabs = sidebar.find(TabInfo);
+    
+    /*
+     * When the filter clears, the tabs that become unfiltered should be
+     * selected.
+     */
+    expect(tabs.length).toEqual(3);
+    for (let i = 0; i < tabs.length; i++) {
+      expect(tabs.at(i).props().tabInfo.selected).toBe(true);
+    }
+
+    filter.simulate("change", { target: { value: "foo" } });
+
+    tabs = sidebar.find(TabInfo);
+    expect(tabs.length).toEqual(1);
+    expect(tabs.at(0).props().tabInfo.selected).toBe(true);
+
+    /* Unfiltered tabs should not be selected. */
+    const currentState = sidebar.state();
+    expect(currentState.tabsById.get(testTabs[0].id).selected).toBe(false);
+    expect(currentState.tabsById.get(testTabs[2].id).selected).toBe(false);
+
+    selectAll.simulate("change", { target: { checked: false } });
+
+    for (let i = 0; i < tabs.length; i++) {
+      expect(tabs.at(i).props().tabInfo.selected).toBe(false);
+    }
+
+    filter.simulate("change", { target: { value: "" } });
+
+    tabs = sidebar.find(TabInfo);
+    expect(tabs.length).toEqual(3);
+    /*
+     * When the filter clears, the tabs that become unfiltered (that were
+     * previously selected before the filter) should be unselected.
+     */
+    for (let i = 0; i < tabs.length; i++) {
+      expect(tabs.at(i).props().tabInfo.selected).toBe(false);
+    }
+  });
 });

--- a/test/components/sidebar.test.jsx
+++ b/test/components/sidebar.test.jsx
@@ -108,4 +108,42 @@ describe("<SideBar /> with multiple tabs", () => {
       }
     });
   });
+
+  test("creating tabs", done => {
+    const sidebar = mount(<SideBar windowId={testWindowId} />);
+
+    setTimeout(() => {
+      try {
+        expect(browser.windows.get.called).toBe(true);
+
+        browser.tabs.onCreated.trigger({
+          favIconUrl: "http://example.com/baz.ico",
+          id: 4,
+          title: "example.com/baz",
+          url: "http://example.com/baz",
+          windowId: testWindowId,
+          index: 3,
+        });
+
+        expect(sidebar.state().tabIds).toEqual([
+          testTabs[0].id,
+          testTabs[1].id,
+          testTabs[2].id,
+          4
+        ]);
+
+        const tabs = sidebar.find(TabInfo);
+
+        expect(tabs.length).toBe(4);
+        expect(tabs.at(0).props().tabInfo.id).toBe(testTabs[0].id);
+        expect(tabs.at(1).props().tabInfo.id).toBe(testTabs[1].id);
+        expect(tabs.at(2).props().tabInfo.id).toBe(testTabs[2].id);
+        expect(tabs.at(3).props().tabInfo.id).toBe(4);
+
+        done();
+      } catch (e) {
+        done.fail(e);
+      }
+    });
+  });
 });

--- a/test/components/sidebar.test.jsx
+++ b/test/components/sidebar.test.jsx
@@ -180,4 +180,48 @@ describe("<SideBar /> with multiple tabs", () => {
     expect(tabInfo.favIconUrl).toEqual(undefined);
     expect(tabInfo.url).toEqual("http://example.com/foobarbaz");
   });
+
+  test("select all", () => {
+    const selectAll = sidebar.find("#select-all");
+    const tabs = sidebar.find(TabInfo);
+    for (let i = 0; i < tabs.length; i++) {
+      expect(tabs.at(i).props().tabInfo.selected).toBe(false);
+    }
+
+    selectAll.simulate("change", { target: { checked: true } });
+    expect(selectAll.props().checked).toBe(true);
+    for (let i = 0; i < tabs.length; i++) {
+      expect(tabs.at(i).props().tabInfo.selected).toBe(true);
+    }
+
+    selectAll.simulate("change", { target: { checked: false } });
+    expect(selectAll.props().checked).toBe(false);
+    for (let i = 0; i < tabs.length; i++) {
+      expect(tabs.at(i).props().tabInfo.selected).toBe(false);
+    } 
+
+    sidebar.find(TabInfo).find("input[type='checkbox']").forEach(node => {
+      node.simulate("change", { target: { checked: true } });
+    });
+
+    expect(selectAll.props().checked).toBe(false);
+    for (let i = 0; i < tabs.length; i++) {
+      expect(tabs.at(i).props().tabInfo.selected).toBe(true);
+    }
+
+    selectAll.simulate("change", { target: { checked: true } });
+    expect(selectAll.props().checked).toBe(true);
+    for (let i = 0; i < tabs.length; i++) {
+      expect(tabs.at(i).props().tabInfo.selected).toBe(true);
+    }
+
+    tabs.at(1).find("input[type='checkbox']").simulate("change", {
+      target: { checked: false },
+    });
+
+    expect(selectAll.props().checked).toBe(false);
+    expect(tabs.at(1).props().tabInfo.selected).toBe(false);
+    expect(tabs.at(0).props().tabInfo.selected).toBe(true);
+    expect(tabs.at(2).props().tabInfo.selected).toBe(true);
+  });
 });

--- a/test/components/sidebar.test.jsx
+++ b/test/components/sidebar.test.jsx
@@ -212,6 +212,12 @@ describe("<SideBar /> with multiple tabs", () => {
         );
 
         expect(tabs.at(1).props().tabInfo.favIconUrl).toEqual(undefined);
+        const tabInfo = sidebar.state().tabsById.get(testTabs[1].id);
+
+        expect(tabInfo.title).toEqual("foo bar baz");
+        expect(tabInfo.hasOwnProperty("favIconUrl")).toBe(true);
+        expect(tabInfo.favIconUrl).toEqual(undefined);
+        expect(tabInfo.url).toEqual("http://example.com/foobarbaz");
 
         done();
       } catch (e) {

--- a/test/components/sidebar.test.jsx
+++ b/test/components/sidebar.test.jsx
@@ -1,0 +1,67 @@
+import "../dom.js";
+
+import { mount } from "enzyme";
+import React from "react";
+import browser from "sinon-chrome";
+
+import SideBar from "components/sidebar";
+
+afterEach(() => browser.reset());
+
+test("<SideBar /> with 0 tabs", done => {
+  browser.windows.get.withArgs(123, { populate: true }).returns(
+    new Promise(resolve =>
+      resolve({
+        tabs: [],
+      }),
+    ),
+  );
+
+  const sidebar = mount(<SideBar windowId={123} />);
+
+  setTimeout(() => {
+    try {
+      expect(browser.windows.get.called).toBe(true);
+      expect(sidebar.find("#tabs-list").children().length).toEqual(0);
+      done();
+    } catch (e) {
+      done.fail(e);
+    }
+  });
+});
+
+test("<SideBar /> with multiple tabs", done => {
+  browser.windows.get.withArgs(123, { populate: true }).returns(
+    new Promise(resolve =>
+      resolve({
+        tabs: [
+          {
+            id: 0,
+            active: true,
+            url: "http://example.com",
+            favIconUrl: undefined,
+            title: "example.com",
+          },
+          {
+            id: 1,
+            url: "http://example.com/foo",
+            favIconUrl: "http://example.com/favicon.ico",
+            title: "example.com/foo",
+          },
+        ],
+      }),
+    ),
+  );
+
+  const sidebar = mount(<SideBar windowId={123} />);
+
+  setTimeout(() => {
+    try {
+      expect(browser.windows.get.called).toBe(true);
+      expect(sidebar.find("#tabs-list").children().length).toEqual(2);
+      done();
+    } catch (e) {
+      done.fail(e);
+    }
+  });
+});

--- a/test/components/sidebar.test.jsx
+++ b/test/components/sidebar.test.jsx
@@ -40,17 +40,20 @@ describe("<SideBar /> with multiple tabs", () => {
       active: true,
       url: "http://example.com",
       title: "example.com",
+      windowId: testWindowId,
     },
     {
       id: 1,
       url: "http://example.com/foo",
       favIconUrl: "http://example.com/favicon.ico",
       title: "example.com/foo",
+      windowId: testWindowId,
     },
     {
       id: 2,
       url: "http://example.com/bar",
       title: "example.com/bar",
+      windowId: testWindowId,
     },
   ];
 
@@ -86,7 +89,7 @@ describe("<SideBar /> with multiple tabs", () => {
         browser.tabs.onMoved.trigger(testTabs[0].id, {
           windowId: testWindowId,
           fromIndex: 0,
-          toIndex: 2
+          toIndex: 2,
         });
 
         expect(sidebar.state().tabIds).toEqual([
@@ -129,7 +132,7 @@ describe("<SideBar /> with multiple tabs", () => {
           testTabs[0].id,
           testTabs[1].id,
           testTabs[2].id,
-          4
+          4,
         ]);
 
         const tabs = sidebar.find(TabInfo);
@@ -161,7 +164,7 @@ describe("<SideBar /> with multiple tabs", () => {
 
         expect(sidebar.state().tabIds).toEqual([
           testTabs[0].id,
-          testTabs[2].id
+          testTabs[2].id,
         ]);
 
         const tabs = sidebar.find(TabInfo);
@@ -169,6 +172,46 @@ describe("<SideBar /> with multiple tabs", () => {
         expect(tabs.length).toBe(2);
         expect(tabs.at(0).props().tabInfo.id).toBe(testTabs[0].id);
         expect(tabs.at(1).props().tabInfo.id).toBe(testTabs[2].id);
+
+        done();
+      } catch (e) {
+        done.fail(e);
+      }
+    });
+  });
+
+  test("updating tabs", done => {
+    const sidebar = mount(<SideBar windowId={testWindowId} />);
+
+    setTimeout(() => {
+      try {
+        expect(browser.windows.get.called).toBe(true);
+        
+        const tabs = sidebar.find(TabInfo);
+
+        browser.tabs.onUpdated.trigger(
+          testTabs[0].id,
+          { favIconUrl: "http://example.com/favicon.ico" },
+          testTabs[0],
+        );
+
+        expect(sidebar.state().tabsById.get(testTabs[0].id).favIconUrl).toEqual(
+          "http://example.com/favicon.ico",
+        );
+
+        expect(tabs.at(0).props().tabInfo.favIconUrl).toEqual("http://example.com/favicon.ico");;
+        
+        browser.tabs.onUpdated.trigger(
+          testTabs[1].id,
+          {
+            title: "foo bar baz",
+            url: "http://example.com/foobarbaz",
+            favIconUrl: undefined,
+          },
+          testTabs[1],
+        );
+
+        expect(tabs.at(1).props().tabInfo.favIconUrl).toEqual(undefined);
 
         done();
       } catch (e) {

--- a/test/components/sidebar.test.jsx
+++ b/test/components/sidebar.test.jsx
@@ -224,4 +224,41 @@ describe("<SideBar /> with multiple tabs", () => {
     expect(tabs.at(0).props().tabInfo.selected).toBe(true);
     expect(tabs.at(2).props().tabInfo.selected).toBe(true);
   });
+
+  test("filtering", () => {
+    const filter = sidebar.find("#filter");
+
+    filter.simulate("change", { target: { value: "EXAMPLE" } });
+    expect(sidebar.state("filter")).toEqual("EXAMPLE");
+    expect(sidebar.find(TabInfo).length).toBe(3);
+
+    filter.simulate("change", { target: { value: "nonexistant" } });
+    expect(sidebar.find(TabInfo).length).toBe(0);
+
+    browser.tabs.onCreated.trigger({
+      favIconUrl: "http://example.com/baz.ico",
+      id: 4,
+      title: "non-existant",
+      url: "http://nonexistant.example.com/",
+      windowId: testWindowId,
+      index: 3,
+    });
+
+    expect(sidebar.find(TabInfo).length).toBe(1);
+
+    browser.tabs.onUpdated.trigger(
+      testTabs[0].id,
+      {
+        url: "about:non-existant",
+        title: "nonexistant",
+        favIconUrl: undefined,
+      },
+      testTabs[0]
+    );
+
+    expect(sidebar.find(TabInfo).length).toBe(2);
+
+    filter.simulate("change", { target: { value: "" } });
+    expect(sidebar.find(TabInfo).length).toBe(4);
+  })
 });

--- a/test/components/sidebar.test.jsx
+++ b/test/components/sidebar.test.jsx
@@ -5,11 +5,14 @@ import React from "react";
 import browser from "sinon-chrome";
 
 import SideBar from "components/sidebar";
+import TabInfo from "components/tabInfo";
 
 afterEach(() => browser.reset());
 
+const testWindowId = 123;
+
 test("<SideBar /> with 0 tabs", done => {
-  browser.windows.get.withArgs(123, { populate: true }).returns(
+  browser.windows.get.withArgs(testWindowId, { populate: true }).returns(
     new Promise(resolve =>
       resolve({
         tabs: [],
@@ -17,7 +20,7 @@ test("<SideBar /> with 0 tabs", done => {
     ),
   );
 
-  const sidebar = mount(<SideBar windowId={123} />);
+  const sidebar = mount(<SideBar windowId={testWindowId} />);
 
   setTimeout(() => {
     try {
@@ -30,38 +33,79 @@ test("<SideBar /> with 0 tabs", done => {
   });
 });
 
-test("<SideBar /> with multiple tabs", done => {
-  browser.windows.get.withArgs(123, { populate: true }).returns(
-    new Promise(resolve =>
-      resolve({
-        tabs: [
-          {
-            id: 0,
-            active: true,
-            url: "http://example.com",
-            favIconUrl: undefined,
-            title: "example.com",
-          },
-          {
-            id: 1,
-            url: "http://example.com/foo",
-            favIconUrl: "http://example.com/favicon.ico",
-            title: "example.com/foo",
-          },
-        ],
-      }),
-    ),
-  );
+describe("<SideBar /> with multiple tabs", () => {
+  const testTabs = [
+    {
+      id: 0,
+      active: true,
+      url: "http://example.com",
+      title: "example.com",
+    },
+    {
+      id: 1,
+      url: "http://example.com/foo",
+      favIconUrl: "http://example.com/favicon.ico",
+      title: "example.com/foo",
+    },
+    {
+      id: 2,
+      url: "http://example.com/bar",
+      title: "example.com/bar",
+    },
+  ];
 
-  const sidebar = mount(<SideBar windowId={123} />);
+  beforeEach(() => {
+    browser.windows.get
+      .withArgs(123, { populate: true })
+      .returns(new Promise(resolve => resolve({ tabs: testTabs.slice() })));
+  });
 
-  setTimeout(() => {
-    try {
-      expect(browser.windows.get.called).toBe(true);
-      expect(sidebar.find("#tabs-list").children().length).toEqual(2);
-      done();
-    } catch (e) {
-      done.fail(e);
-    }
+  test("rendering", done => {
+    const sidebar = mount(<SideBar windowId={testWindowId} />);
+
+    setTimeout(() => {
+      try {
+        expect(browser.windows.get.called).toBe(true);
+        expect(sidebar.find("#tabs-list").children().length).toEqual(
+          testTabs.length,
+        );
+        done();
+      } catch (e) {
+        done.fail(e);
+      }
+    });
+  });
+
+  test("moving tabs", done => {
+    const sidebar = mount(<SideBar windowId={testWindowId} />);
+
+    setTimeout(() => {
+      try {
+        expect(browser.windows.get.called).toBe(true);
+
+        browser.tabs.onMoved.trigger(testTabs[0].id, {
+          windowId: testWindowId,
+          fromIndex: 0,
+          toIndex: 2
+        });
+
+        expect(sidebar.state().tabIds).toEqual([
+          testTabs[1].id,
+          testTabs[2].id,
+          testTabs[0].id,
+        ]);
+
+        const tabs = sidebar.find(TabInfo);
+
+        expect(tabs.length).toBe(3);
+        expect(tabs.at(0).props().tabInfo.id).toBe(testTabs[1].id);
+        expect(tabs.at(1).props().tabInfo.id).toBe(testTabs[2].id);
+        expect(tabs.at(2).props().tabInfo.id).toBe(testTabs[0].id);
+
+        done();
+      } catch (e) {
+        done.fail(e);
+      }
+    });
   });
 });

--- a/test/components/tabInfo.test.jsx
+++ b/test/components/tabInfo.test.jsx
@@ -12,7 +12,6 @@ afterEach(() => browser.reset());
 test("Rendering <TabInfo favIconUrl='...' />", () => {
   const info = {
     favIconUrl: "http://example.com/favicon.ico",
-    filtered: false,
     id: 1,
     selected: false,
     title: "example.com",
@@ -30,7 +29,7 @@ test("Rendering <TabInfo favIconUrl='...' />", () => {
 
   expect(
     tabInfo.matchesElement(
-      <li className="">
+      <li>
         <label>
           <input type="checkbox" />
           <img className="favicon" src="http://example.com/favicon.ico" />
@@ -44,7 +43,6 @@ test("Rendering <TabInfo favIconUrl='...' />", () => {
 test("Rendering <TabInfo favIconUrl={undefined} />", () => {
   const info = {
     id: 1,
-    filtered: false,
     selected: false,
     title: "example.com",
     url: "http://example.com",
@@ -61,31 +59,6 @@ test("Rendering <TabInfo favIconUrl={undefined} />", () => {
   const favIcon = tabInfo.find(".favicon");
   expect(favIcon.exists()).toBe(true);
   expect(favIcon.prop("src")).toBe(undefined);
-  expect(tabInfo.hasClass("filtered")).toBe(false);
-  expect(tabInfo.hasClass("active")).toBe(false);
-  expect(tabInfo.find("[type='checkbox']").props().checked).toBeFalsy();
-  expect(tabInfo.find("label").text()).toEqual("example.com");
-});
-
-test("Rendering <TabInfo filtered={true} />", () => {
-  const info = {
-    id: 1,
-    filtered: true,
-    selected: false,
-    title: "example.com",
-    url: "http://example.com",
-  };
-
-  const tabInfo = shallow(
-    <TabInfo
-      active={false}
-      tabInfo={info}
-      onClick={noop}
-      onSelectionChanged={noop}
-    />,
-  );
-
-  expect(tabInfo.hasClass("filtered")).toBe(true);
   expect(tabInfo.hasClass("active")).toBe(false);
   expect(tabInfo.find("[type='checkbox']").props().checked).toBeFalsy();
   expect(tabInfo.find("label").text()).toEqual("example.com");
@@ -94,7 +67,6 @@ test("Rendering <TabInfo filtered={true} />", () => {
 test("Rendering <TabInfo active={true} />", () => {
   const info = {
     id: 1,
-    filtered: false,
     selected: false,
     title: "example.com",
     url: "http://example.com",
@@ -108,30 +80,6 @@ test("Rendering <TabInfo active={true} />", () => {
     />,
   );
 
-  expect(tabInfo.hasClass("active")).toBe(true);
-  expect(tabInfo.hasClass("filtered")).toBe(false);
-  expect(tabInfo.find("[type='checkbox']").props().checked).toBeFalsy();
-  expect(tabInfo.find("label").text()).toEqual("example.com");
-});
-
-test("Rendering <TabInfo filtered={true} active={true} />", () => {
-  const info = {
-    id: 1,
-    filtered: true,
-    selected: false,
-    title: "example.com",
-    url: "http://example.com",
-  };
-  const tabInfo = shallow(
-    <TabInfo
-      active={true}
-      tabInfo={info}
-      onClick={noop}
-      onSelectionChanged={noop}
-    />,
-  );
-
-  expect(tabInfo.hasClass("filtered")).toBe(true);
   expect(tabInfo.hasClass("active")).toBe(true);
   expect(tabInfo.find("[type='checkbox']").props().checked).toBeFalsy();
   expect(tabInfo.find("label").text()).toEqual("example.com");
@@ -140,7 +88,6 @@ test("Rendering <TabInfo filtered={true} active={true} />", () => {
 test("Rendering <TabInfo selected={true} />", () => {
   const info = {
     id: 1,
-    filtered: false,
     selected: true,
     title: "example.com",
     url: "http://example.com",
@@ -154,7 +101,6 @@ test("Rendering <TabInfo selected={true} />", () => {
     />,
   );
 
-  expect(tabInfo.hasClass("filtered")).toBe(false);
   expect(tabInfo.hasClass("active")).toBe(false);
   expect(tabInfo.find("[type='checkbox']").props().checked).toBe(true);
   expect(tabInfo.find("label").text()).toEqual("example.com");
@@ -163,7 +109,6 @@ test("Rendering <TabInfo selected={true} />", () => {
 test("Rendering <TabInfo selected={true} active={true} />", () => {
   const info = {
     id: 1,
-    filtered: false,
     selected: true,
     title: "example.com",
     url: "http://example.com",
@@ -177,7 +122,6 @@ test("Rendering <TabInfo selected={true} active={true} />", () => {
     />,
   );
 
-  expect(tabInfo.hasClass("filtered")).toBe(false);
   expect(tabInfo.hasClass("active")).toBe(true);
   expect(tabInfo.find("[type='checkbox']").props().checked).toBe(true);
   expect(tabInfo.find("label").text()).toEqual("example.com");

--- a/test/components/tabInfo.test.jsx
+++ b/test/components/tabInfo.test.jsx
@@ -1,0 +1,184 @@
+import "../dom.js";
+
+import { shallow } from "enzyme";
+import React from "react";
+
+import TabInfo from "components/tabInfo";
+
+const noop = function noop() {};
+
+afterEach(() => browser.reset());
+
+test("Rendering <TabInfo favIconUrl='...' />", () => {
+  const info = {
+    favIconUrl: "http://example.com/favicon.ico",
+    filtered: false,
+    id: 1,
+    selected: false,
+    title: "example.com",
+    url: "http://example.com",
+  };
+
+  const tabInfo = shallow(
+    <TabInfo
+      active={false}
+      tabInfo={info}
+      onClick={noop}
+      onSelectionChanged={noop}
+    />,
+  );
+
+  expect(
+    tabInfo.matchesElement(
+      <li className="">
+        <label>
+          <input type="checkbox" />
+          <img className="favicon" src="http://example.com/favicon.ico" />
+          example.com
+        </label>
+      </li>,
+    ),
+  ).toBe(true);
+});
+
+test("Rendering <TabInfo favIconUrl={undefined} />", () => {
+  const info = {
+    id: 1,
+    filtered: false,
+    selected: false,
+    title: "example.com",
+    url: "http://example.com",
+  };
+  const tabInfo = shallow(
+    <TabInfo
+      active={false}
+      tabInfo={info}
+      onClick={noop}
+      onSelectionChanged={noop}
+    />,
+  );
+
+  const favIcon = tabInfo.find(".favicon");
+  expect(favIcon.exists()).toBe(true);
+  expect(favIcon.prop("src")).toBe(undefined);
+  expect(tabInfo.hasClass("filtered")).toBe(false);
+  expect(tabInfo.hasClass("active")).toBe(false);
+  expect(tabInfo.find("[type='checkbox']").props().checked).toBeFalsy();
+  expect(tabInfo.find("label").text()).toEqual("example.com");
+});
+
+test("Rendering <TabInfo filtered={true} />", () => {
+  const info = {
+    id: 1,
+    filtered: true,
+    selected: false,
+    title: "example.com",
+    url: "http://example.com",
+  };
+
+  const tabInfo = shallow(
+    <TabInfo
+      active={false}
+      tabInfo={info}
+      onClick={noop}
+      onSelectionChanged={noop}
+    />,
+  );
+
+  expect(tabInfo.hasClass("filtered")).toBe(true);
+  expect(tabInfo.hasClass("active")).toBe(false);
+  expect(tabInfo.find("[type='checkbox']").props().checked).toBeFalsy();
+  expect(tabInfo.find("label").text()).toEqual("example.com");
+});
+
+test("Rendering <TabInfo active={true} />", () => {
+  const info = {
+    id: 1,
+    filtered: false,
+    selected: false,
+    title: "example.com",
+    url: "http://example.com",
+  };
+  const tabInfo = shallow(
+    <TabInfo
+      active={true}
+      tabInfo={info}
+      onClick={noop}
+      onSelectionChanged={noop}
+    />,
+  );
+
+  expect(tabInfo.hasClass("active")).toBe(true);
+  expect(tabInfo.hasClass("filtered")).toBe(false);
+  expect(tabInfo.find("[type='checkbox']").props().checked).toBeFalsy();
+  expect(tabInfo.find("label").text()).toEqual("example.com");
+});
+
+test("Rendering <TabInfo filtered={true} active={true} />", () => {
+  const info = {
+    id: 1,
+    filtered: true,
+    selected: false,
+    title: "example.com",
+    url: "http://example.com",
+  };
+  const tabInfo = shallow(
+    <TabInfo
+      active={true}
+      tabInfo={info}
+      onClick={noop}
+      onSelectionChanged={noop}
+    />,
+  );
+
+  expect(tabInfo.hasClass("filtered")).toBe(true);
+  expect(tabInfo.hasClass("active")).toBe(true);
+  expect(tabInfo.find("[type='checkbox']").props().checked).toBeFalsy();
+  expect(tabInfo.find("label").text()).toEqual("example.com");
+});
+
+test("Rendering <TabInfo selected={true} />", () => {
+  const info = {
+    id: 1,
+    filtered: false,
+    selected: true,
+    title: "example.com",
+    url: "http://example.com",
+  };
+  const tabInfo = shallow(
+    <TabInfo
+      active={false}
+      tabInfo={info}
+      onClick={noop}
+      onSelectionChanged={noop}
+    />,
+  );
+
+  expect(tabInfo.hasClass("filtered")).toBe(false);
+  expect(tabInfo.hasClass("active")).toBe(false);
+  expect(tabInfo.find("[type='checkbox']").props().checked).toBe(true);
+  expect(tabInfo.find("label").text()).toEqual("example.com");
+});
+
+test("Rendering <TabInfo selected={true} active={true} />", () => {
+  const info = {
+    id: 1,
+    filtered: false,
+    selected: true,
+    title: "example.com",
+    url: "http://example.com",
+  };
+  const tabInfo = shallow(
+    <TabInfo
+      active={true}
+      tabInfo={info}
+      onClick={noop}
+      onSelectionChanged={noop}
+    />,
+  );
+
+  expect(tabInfo.hasClass("filtered")).toBe(false);
+  expect(tabInfo.hasClass("active")).toBe(true);
+  expect(tabInfo.find("[type='checkbox']").props().checked).toBe(true);
+  expect(tabInfo.find("label").text()).toEqual("example.com");
+});

--- a/test/components/tabInfo.test.jsx
+++ b/test/components/tabInfo.test.jsx
@@ -1,4 +1,4 @@
-import "../dom.js";
+import "../dom";
 
 import { shallow } from "enzyme";
 import React from "react";

--- a/test/dom.js
+++ b/test/dom.js
@@ -1,0 +1,20 @@
+import {JSDOM} from "jsdom";
+import browser from "sinon-chrome";
+
+const copyProps = function copyProps(src, target) {
+  const props = Object
+    .getOwnPropertyNames(src)
+    .filter(prop => typeof target[prop] === 'undefined')
+    .map(prop => Object.getOwnPropertyDescriptor(src, prop));
+
+  Object.defineProperties(target, props);
+}
+
+global.browser = browser;
+global.window = new JSDOM("<!doctype html><html><body></body></html>").window;
+global.document = window.document;
+global.navigator = {
+  userAgent: 'node.js',
+};
+
+copyProps(window, global);

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,8 @@
+/**
+ * A promise that resolves once the rest of the stack has cleared.
+ *
+ * Useful if you are waiting for other promises to resolve.
+ */
+export const defer = function defer() {
+  return new Promise(resolve => setTimeout(resolve));
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,20 +30,7 @@ module.exports = {
           },
         },
       },
-      { test: /\.js$/, exclude: /node_modules/, use: "babel-loader" },
-      {
-        test: /\.jsx$/,
-        exclude: /node_modules/,
-        use: {
-          loader: "babel-loader",
-          options: { 
-            presets: ["babel-preset-react"],
-            plugins: [
-              ["transform-class-properties", {"spec": true}],
-            ],
-          }, 
-        },
-      },
+      { test: /\.jsx?$/, exclude: /node_modules/, use: "babel-loader" },
     ],
   },
   plugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -238,6 +238,10 @@ babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-transform-class-properties@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
@@ -252,6 +256,13 @@ babel-plugin-transform-flow-strip-types@^6.22.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz#84cb672935d43714fdc32bce84568d87441cf7cf"
   dependencies:
     babel-plugin-syntax-flow "^6.18.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz#875d6bc9be761c58a2ae3feee5dc4895d8c7f921"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-react-display-name@^6.23.0:
@@ -664,8 +675,8 @@ date-now@^0.1.4:
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
 debug@^2.1.1, debug@^2.2.0:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz#92bad1f6d05bbb6bba22cca88bcd0ec894c2861e"
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
     ms "2.0.0"
 
@@ -937,13 +948,13 @@ glob-parent@^2.0.0:
     is-glob "^2.0.0"
 
 glob@^7.0.5:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.2"
+    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -1348,7 +1359,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-minimatch@^3.0.0, minimatch@^3.0.2:
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -1924,10 +1935,10 @@ string_decoder@^0.10.25:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
 string_decoder@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.0.tgz#f06f41157b664d86069f84bdbdc9b0d8ab281667"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.1.tgz#62e200f039955a6810d8df0a33ffc0f013662d98"
   dependencies:
-    buffer-shims "~1.0.0"
+    safe-buffer "^5.0.1"
 
 stringstream@~0.0.4:
   version "0.0.5"
@@ -2027,8 +2038,8 @@ ua-parser-js@^0.7.9:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
 uglify-js@^2.8.5:
-  version "2.8.26"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.26.tgz#3a1db8ae0a0aba7f92e1ddadadbd0293d549f90e"
+  version "2.8.27"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.27.tgz#47787f912b0f242e5b984343be8e35e95f694c9c"
   dependencies:
     source-map "~0.5.1"
     yargs "~3.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+abab@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -12,7 +16,13 @@ acorn-dynamic-import@^2.0.0:
   dependencies:
     acorn "^4.0.3"
 
-acorn@^4.0.3:
+acorn-globals@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
+  dependencies:
+    acorn "^4.0.4"
+
+acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
 
@@ -39,7 +49,15 @@ align-text@^0.1.1, align-text@^0.1.3:
     longest "^1.0.1"
     repeat-string "^1.5.2"
 
-ansi-regex@^2.0.0:
+amdefine@>=0.0.4:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+
+ansi-escapes@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
+
+ansi-regex@^2.0.0, ansi-regex@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
@@ -47,12 +65,24 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.0.0.tgz#5404e93a544c4fec7f048262977bebfe3155e0c1"
+  dependencies:
+    color-convert "^1.0.0"
+
 anymatch@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
   dependencies:
     arrify "^1.0.0"
     micromatch "^2.1.5"
+
+append-transform@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
+  dependencies:
+    default-require-extensions "^1.0.0"
 
 aproba@^1.0.3:
   version "1.1.1"
@@ -65,6 +95,12 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+argparse@^1.0.7:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
+  dependencies:
+    sprintf-js "~1.0.2"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -75,11 +111,15 @@ arr-flatten@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.3.tgz#a274ed85ac08849b6bd7847c4580745dc51adfb1"
 
+array-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
+
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
-arrify@^1.0.0:
+arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
@@ -117,7 +157,11 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
-async@^2.1.2:
+async@^1.4.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+
+async@^2.1.2, async@^2.1.4:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.4.0.tgz#4990200f18ea5b837c2cc4f8c031a6985c385611"
   dependencies:
@@ -143,7 +187,7 @@ babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-core@^6.24.1:
+babel-core@^6.0.0, babel-core@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.24.1.tgz#8c428564dce1e1f41fb337ec34f4c3b022b5ad83"
   dependencies:
@@ -167,7 +211,7 @@ babel-core@^6.24.1:
     slash "^1.0.0"
     source-map "^0.5.0"
 
-babel-generator@^6.24.1:
+babel-generator@^6.18.0, babel-generator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.24.1.tgz#e715f486c58ded25649d888944d52aa07c5d9497"
   dependencies:
@@ -212,6 +256,14 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
+babel-jest@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-20.0.3.tgz#e4a03b13dc10389e140fc645d09ffc4ced301671"
+  dependencies:
+    babel-core "^6.0.0"
+    babel-plugin-istanbul "^4.0.0"
+    babel-preset-jest "^20.0.3"
+
 babel-loader@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.0.0.tgz#2e43a66bee1fff4470533d0402c8a4532fafbaf7"
@@ -225,6 +277,18 @@ babel-messages@^6.23.0:
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
   dependencies:
     babel-runtime "^6.22.0"
+
+babel-plugin-istanbul@^4.0.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.3.tgz#6ee6280410dcf59c7747518c3dfd98680958f102"
+  dependencies:
+    find-up "^2.1.0"
+    istanbul-lib-instrument "^1.7.1"
+    test-exclude "^4.1.0"
+
+babel-plugin-jest-hoist@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz#afedc853bd3f8dc3548ea671fbe69d03cc2c1767"
 
 babel-plugin-syntax-class-properties@^6.8.0:
   version "6.13.0"
@@ -250,6 +314,15 @@ babel-plugin-transform-class-properties@^6.24.1:
     babel-plugin-syntax-class-properties "^6.8.0"
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz#d3e310b40ef664a36622200097c6d440298f2bfe"
+  dependencies:
+    babel-plugin-transform-strict-mode "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-types "^6.24.1"
 
 babel-plugin-transform-flow-strip-types@^6.22.0:
   version "6.22.0"
@@ -293,11 +366,24 @@ babel-plugin-transform-react-jsx@^6.24.1:
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-strict-mode@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
 babel-preset-flow@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz#e71218887085ae9a24b5be4169affb599816c49d"
   dependencies:
     babel-plugin-transform-flow-strip-types "^6.22.0"
+
+babel-preset-jest@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz#cbacaadecb5d689ca1e1de1360ebfc66862c178a"
+  dependencies:
+    babel-plugin-jest-hoist "^20.0.3"
 
 babel-preset-react@^6.24.1:
   version "6.24.1"
@@ -329,7 +415,7 @@ babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@^6.24.1:
+babel-template@^6.16.0, babel-template@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
   dependencies:
@@ -339,7 +425,7 @@ babel-template@^6.24.1:
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.24.1:
+babel-traverse@^6.18.0, babel-traverse@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
   dependencies:
@@ -353,7 +439,7 @@ babel-traverse@^6.24.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.24.1:
+babel-types@^6.18.0, babel-types@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
   dependencies:
@@ -362,7 +448,7 @@ babel-types@^6.24.1:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.11.0, babylon@^6.15.0:
+babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0:
   version "6.17.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.1.tgz#17f14fddf361b695981fe679385e4f1c01ebd86f"
 
@@ -398,6 +484,10 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
 
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -422,6 +512,12 @@ braces@^1.8.2:
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+
+browser-resolve@^1.11.2:
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
+  dependencies:
+    resolve "1.1.7"
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.0.6"
@@ -474,6 +570,18 @@ browserify-zlib@^0.1.4:
   dependencies:
     pako "~0.2.0"
 
+bser@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bser/-/bser-1.0.2.tgz#381116970b2a6deea5646dd15dd7278444b56169"
+  dependencies:
+    node-int64 "^0.4.0"
+
+bser@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
+  dependencies:
+    node-int64 "^0.4.0"
+
 buffer-shims@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
@@ -498,6 +606,10 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
+callsites@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
+
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
@@ -517,7 +629,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@^1.1.0:
+chalk@^1.1.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -526,6 +638,27 @@ chalk@^1.1.0:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+cheerio@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.22.0.tgz#a9baa860a3f9b595a6b81b1a86873121ed3a269e"
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash.assignin "^4.0.9"
+    lodash.bind "^4.1.4"
+    lodash.defaults "^4.0.1"
+    lodash.filter "^4.4.0"
+    lodash.flatten "^4.2.0"
+    lodash.foreach "^4.3.0"
+    lodash.map "^4.4.0"
+    lodash.merge "^4.4.0"
+    lodash.pick "^4.2.1"
+    lodash.reduce "^4.4.0"
+    lodash.reject "^4.4.0"
+    lodash.some "^4.4.0"
 
 chokidar@^1.4.3:
   version "1.7.0"
@@ -541,6 +674,10 @@ chokidar@^1.4.3:
     readdirp "^2.0.0"
   optionalDependencies:
     fsevents "^1.0.0"
+
+ci-info@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.0.0.tgz#dc5285f2b4e251821683681c381c3388f46ec534"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.3"
@@ -572,6 +709,16 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+color-convert@^1.0.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  dependencies:
+    color-name "^1.1.1"
+
+color-name@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.2.tgz#5c8ab72b64bd2215d617ae9559ebb148475cf98d"
+
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
@@ -600,7 +747,11 @@ constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
 
-convert-source-map@^1.1.0:
+content-type-parser@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.1.tgz#c3e56988c53c65127fb46d4032a3a900246fdc94"
+
+convert-source-map@^1.1.0, convert-source-map@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
@@ -664,6 +815,29 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
 
+css-select@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
+css-what@2.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
+
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
+
+"cssstyle@>= 0.2.37 < 0.3.0":
+  version "0.2.37"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
+  dependencies:
+    cssom "0.3.x"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -674,7 +848,7 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@^2.1.1, debug@^2.2.0:
+debug@^2.1.1, debug@^2.2.0, debug@^2.6.3:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -687,6 +861,23 @@ decamelize@^1.0.0, decamelize@^1.1.1:
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
+
+deep-is@~0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
+default-require-extensions@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
+  dependencies:
+    strip-bom "^2.0.0"
+
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -709,6 +900,10 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+diff@^3.1.0, diff@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
+
 diffie-hellman@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.2.tgz#b5835739270cfe26acf632099fded2a07f209e5e"
@@ -717,9 +912,37 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+dom-serializer@0, dom-serializer@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+  dependencies:
+    domelementtype "~1.1.1"
+    entities "~1.1.1"
+
 domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
+
+domelementtype@1, domelementtype@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+
+domelementtype@~1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
+
+domhandler@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
+  dependencies:
+    domelementtype "1"
+
+domutils@1.5.1, domutils@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -758,7 +981,26 @@ enhanced-resolve@^3.0.0:
     object-assign "^4.0.1"
     tapable "^0.2.5"
 
-errno@^0.1.3:
+entities@^1.1.1, entities@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+enzyme@^2.8.2:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-2.8.2.tgz#6c8bcb05012abc4aa4bc3213fb23780b9b5b1714"
+  dependencies:
+    cheerio "^0.22.0"
+    function.prototype.name "^1.0.0"
+    is-subset "^0.1.1"
+    lodash "^4.17.2"
+    object-is "^1.0.1"
+    object.assign "^4.0.4"
+    object.entries "^1.0.3"
+    object.values "^1.0.3"
+    prop-types "^15.5.4"
+    uuid "^2.0.3"
+
+"errno@>=0.1.1 <0.2.0-0", errno@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
   dependencies:
@@ -770,9 +1012,49 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-abstract@^1.6.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.0"
+    is-callable "^1.1.3"
+    is-regex "^1.0.3"
+
+es-to-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+  dependencies:
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
+
 escape-string-regexp@^1.0.2:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+escodegen@^1.6.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.8.1.tgz#5a5b53af4693110bebb0867aa3430dd3b70a1018"
+  dependencies:
+    esprima "^2.7.1"
+    estraverse "^1.9.1"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.2.0"
+
+esprima@^2.7.1:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+
+esprima@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+
+estraverse@^1.9.1:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
 
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
@@ -787,6 +1069,12 @@ evp_bytestokey@^1.0.0:
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz#497b66ad9fef65cd7c08a6180824ba1476b66e53"
   dependencies:
     create-hash "^1.1.1"
+
+exec-sh@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.0.tgz#14f75de3f20d286ef933099b2ce50a90359cef10"
+  dependencies:
+    merge "^1.1.3"
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -814,6 +1102,22 @@ extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
 
+fast-levenshtein@~2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
+fb-watchman@^1.8.0:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-1.9.2.tgz#a24cf47827f82d38fb59a69ad70b76e3b6ae7383"
+  dependencies:
+    bser "1.0.2"
+
+fb-watchman@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
+  dependencies:
+    bser "^2.0.0"
+
 fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
@@ -835,6 +1139,13 @@ file-loader@^0.11.1:
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
+
+fileset@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/fileset/-/fileset-2.0.3.tgz#8e7548a96d3cc2327ee5e674168723a333bba2a0"
+  dependencies:
+    glob "^7.0.3"
+    minimatch "^3.0.3"
 
 fill-range@^2.1.0:
   version "2.2.3"
@@ -861,6 +1172,12 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
+find-up@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  dependencies:
+    locate-path "^2.0.0"
+
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -870,6 +1187,10 @@ for-own@^0.1.4:
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
   dependencies:
     for-in "^1.0.1"
+
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -882,6 +1203,12 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formatio@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
+  dependencies:
+    samsam "1.x"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -910,6 +1237,18 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     inherits "~2.0.0"
     mkdirp ">=0.5 0"
     rimraf "2"
+
+function-bind@^1.0.2, function-bind@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
+
+function.prototype.name@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.0.0.tgz#5f523ca64e491a5f95aba80cc1e391080a14482e"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.0"
+    is-callable "^1.1.2"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -947,7 +1286,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.5:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -962,9 +1301,23 @@ globals@^9.0.0:
   version "9.17.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.17.0.tgz#0c0ca696d9b9bb694d2e5470bd37777caad50286"
 
-graceful-fs@^4.1.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+growly@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+
+handlebars@^4.0.3:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.8.tgz#22b875cd3f0e6cbea30314f144e82bc7a72ff420"
+  dependencies:
+    async "^1.4.0"
+    optimist "^0.6.1"
+    source-map "^0.4.4"
+  optionalDependencies:
+    uglify-js "^2.6"
 
 har-schema@^1.0.5:
   version "1.0.5"
@@ -990,6 +1343,12 @@ has-flag@^1.0.0:
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+
+has@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
+  dependencies:
+    function-bind "^1.0.2"
 
 hash-base@^2.0.0:
   version "2.0.2"
@@ -1035,6 +1394,23 @@ hosted-git-info@^2.1.4:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.4.2.tgz#0076b9f46a270506ddbaaea56496897460612a67"
 
+html-encoding-sniffer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz#79bf7a785ea495fe66165e734153f363ff5437da"
+  dependencies:
+    whatwg-encoding "^1.0.1"
+
+htmlparser2@^3.9.1:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
@@ -1047,9 +1423,9 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
-iconv-lite@~0.4.13:
-  version "0.4.17"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.17.tgz#4fdaa3b38acbc2c031b045d0edcdfe1ecab18c8d"
+iconv-lite@0.4.13, iconv-lite@~0.4.13:
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
 ieee754@^1.1.4:
   version "1.1.8"
@@ -1112,6 +1488,20 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
+is-callable@^1.1.1, is-callable@^1.1.2, is-callable@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+
+is-ci@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
+  dependencies:
+    ci-info "^1.0.0"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
 is-dotfile@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.2.tgz#2c132383f39199f8edc268ca01b9b007d205cc4d"
@@ -1162,9 +1552,23 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-regex@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  dependencies:
+    has "^1.0.1"
+
 is-stream@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-subset@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
+
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -1174,9 +1578,17 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -1195,6 +1607,280 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
+istanbul-api@^1.1.1:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.1.8.tgz#a844e55c6f9aeee292e7f42942196f60b23dc93e"
+  dependencies:
+    async "^2.1.4"
+    fileset "^2.0.2"
+    istanbul-lib-coverage "^1.1.0"
+    istanbul-lib-hook "^1.0.6"
+    istanbul-lib-instrument "^1.7.1"
+    istanbul-lib-report "^1.1.0"
+    istanbul-lib-source-maps "^1.2.0"
+    istanbul-reports "^1.1.0"
+    js-yaml "^3.7.0"
+    mkdirp "^0.5.1"
+    once "^1.4.0"
+
+istanbul-lib-coverage@^1.0.1, istanbul-lib-coverage@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#caca19decaef3525b5d6331d701f3f3b7ad48528"
+
+istanbul-lib-hook@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.0.6.tgz#c0866d1e81cf2d5319249510131fc16dee49231f"
+  dependencies:
+    append-transform "^0.4.0"
+
+istanbul-lib-instrument@^1.4.2, istanbul-lib-instrument@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.1.tgz#169e31bc62c778851a99439dd99c3cc12184d360"
+  dependencies:
+    babel-generator "^6.18.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
+    babylon "^6.13.0"
+    istanbul-lib-coverage "^1.1.0"
+    semver "^5.3.0"
+
+istanbul-lib-report@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.0.tgz#444c4ecca9afa93cf584f56b10f195bf768c0770"
+  dependencies:
+    istanbul-lib-coverage "^1.1.0"
+    mkdirp "^0.5.1"
+    path-parse "^1.0.5"
+    supports-color "^3.1.2"
+
+istanbul-lib-source-maps@^1.1.0, istanbul-lib-source-maps@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.0.tgz#8c7706d497e26feeb6af3e0c28fd5b0669598d0e"
+  dependencies:
+    debug "^2.6.3"
+    istanbul-lib-coverage "^1.1.0"
+    mkdirp "^0.5.1"
+    rimraf "^2.6.1"
+    source-map "^0.5.3"
+
+istanbul-reports@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.0.tgz#1ef3b795889219cfb5fad16365f6ce108d5f8c66"
+  dependencies:
+    handlebars "^4.0.3"
+
+jest-changed-files@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-20.0.3.tgz#9394d5cc65c438406149bef1bf4d52b68e03e3f8"
+
+jest-cli@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-20.0.3.tgz#fe88ddbb7a9f3a16d0ed55339a0a2424f7f0d361"
+  dependencies:
+    ansi-escapes "^1.4.0"
+    callsites "^2.0.0"
+    chalk "^1.1.3"
+    graceful-fs "^4.1.11"
+    is-ci "^1.0.10"
+    istanbul-api "^1.1.1"
+    istanbul-lib-coverage "^1.0.1"
+    istanbul-lib-instrument "^1.4.2"
+    istanbul-lib-source-maps "^1.1.0"
+    jest-changed-files "^20.0.3"
+    jest-config "^20.0.3"
+    jest-docblock "^20.0.3"
+    jest-environment-jsdom "^20.0.3"
+    jest-haste-map "^20.0.3"
+    jest-jasmine2 "^20.0.3"
+    jest-message-util "^20.0.3"
+    jest-regex-util "^20.0.3"
+    jest-resolve-dependencies "^20.0.3"
+    jest-runtime "^20.0.3"
+    jest-snapshot "^20.0.3"
+    jest-util "^20.0.3"
+    micromatch "^2.3.11"
+    node-notifier "^5.0.2"
+    pify "^2.3.0"
+    slash "^1.0.0"
+    string-length "^1.0.1"
+    throat "^3.0.0"
+    which "^1.2.12"
+    worker-farm "^1.3.1"
+    yargs "^7.0.2"
+
+jest-config@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-20.0.3.tgz#a934f27eea764915801cdda26f6f8eec2ac79266"
+  dependencies:
+    chalk "^1.1.3"
+    glob "^7.1.1"
+    jest-environment-jsdom "^20.0.3"
+    jest-environment-node "^20.0.3"
+    jest-jasmine2 "^20.0.3"
+    jest-matcher-utils "^20.0.3"
+    jest-regex-util "^20.0.3"
+    jest-resolve "^20.0.3"
+    jest-validate "^20.0.3"
+    pretty-format "^20.0.3"
+
+jest-diff@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-20.0.3.tgz#81f288fd9e675f0fb23c75f1c2b19445fe586617"
+  dependencies:
+    chalk "^1.1.3"
+    diff "^3.2.0"
+    jest-matcher-utils "^20.0.3"
+    pretty-format "^20.0.3"
+
+jest-docblock@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
+
+jest-environment-jsdom@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz#048a8ac12ee225f7190417713834bb999787de99"
+  dependencies:
+    jest-mock "^20.0.3"
+    jest-util "^20.0.3"
+    jsdom "^9.12.0"
+
+jest-environment-node@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-20.0.3.tgz#d488bc4612af2c246e986e8ae7671a099163d403"
+  dependencies:
+    jest-mock "^20.0.3"
+    jest-util "^20.0.3"
+
+jest-haste-map@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-20.0.3.tgz#6377d537eaf34eb5f75121a691cae3fde82ba971"
+  dependencies:
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.11"
+    jest-docblock "^20.0.3"
+    micromatch "^2.3.11"
+    sane "~1.6.0"
+    worker-farm "^1.3.1"
+
+jest-jasmine2@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-20.0.3.tgz#18c4e9d029da7ed1ae727c55300064d1a0542974"
+  dependencies:
+    chalk "^1.1.3"
+    graceful-fs "^4.1.11"
+    jest-diff "^20.0.3"
+    jest-matcher-utils "^20.0.3"
+    jest-matchers "^20.0.3"
+    jest-message-util "^20.0.3"
+    jest-snapshot "^20.0.3"
+    once "^1.4.0"
+    p-map "^1.1.1"
+
+jest-matcher-utils@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz#b3a6b8e37ca577803b0832a98b164f44b7815612"
+  dependencies:
+    chalk "^1.1.3"
+    pretty-format "^20.0.3"
+
+jest-matchers@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-matchers/-/jest-matchers-20.0.3.tgz#ca69db1c32db5a6f707fa5e0401abb55700dfd60"
+  dependencies:
+    jest-diff "^20.0.3"
+    jest-matcher-utils "^20.0.3"
+    jest-message-util "^20.0.3"
+    jest-regex-util "^20.0.3"
+
+jest-message-util@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-20.0.3.tgz#6aec2844306fcb0e6e74d5796c1006d96fdd831c"
+  dependencies:
+    chalk "^1.1.3"
+    micromatch "^2.3.11"
+    slash "^1.0.0"
+
+jest-mock@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-20.0.3.tgz#8bc070e90414aa155c11a8d64c869a0d5c71da59"
+
+jest-regex-util@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-20.0.3.tgz#85bbab5d133e44625b19faf8c6aa5122d085d762"
+
+jest-resolve-dependencies@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz#6e14a7b717af0f2cb3667c549de40af017b1723a"
+  dependencies:
+    jest-regex-util "^20.0.3"
+
+jest-resolve@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-20.0.3.tgz#375307aa40f78532d40ff8b17d5300b1519f8dd4"
+  dependencies:
+    browser-resolve "^1.11.2"
+    is-builtin-module "^1.0.0"
+    resolve "^1.3.2"
+
+jest-runtime@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-20.0.3.tgz#dddd22bbc429e26e6a96d1acd46ca55714b09252"
+  dependencies:
+    babel-core "^6.0.0"
+    babel-jest "^20.0.3"
+    babel-plugin-istanbul "^4.0.0"
+    chalk "^1.1.3"
+    convert-source-map "^1.4.0"
+    graceful-fs "^4.1.11"
+    jest-config "^20.0.3"
+    jest-haste-map "^20.0.3"
+    jest-regex-util "^20.0.3"
+    jest-resolve "^20.0.3"
+    jest-util "^20.0.3"
+    json-stable-stringify "^1.0.1"
+    micromatch "^2.3.11"
+    strip-bom "3.0.0"
+    yargs "^7.0.2"
+
+jest-snapshot@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-20.0.3.tgz#5b847e1adb1a4d90852a7f9f125086e187c76566"
+  dependencies:
+    chalk "^1.1.3"
+    jest-diff "^20.0.3"
+    jest-matcher-utils "^20.0.3"
+    jest-util "^20.0.3"
+    natural-compare "^1.4.0"
+    pretty-format "^20.0.3"
+
+jest-util@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-20.0.3.tgz#0c07f7d80d82f4e5a67c6f8b9c3fe7f65cfd32ad"
+  dependencies:
+    chalk "^1.1.3"
+    graceful-fs "^4.1.11"
+    jest-message-util "^20.0.3"
+    jest-mock "^20.0.3"
+    jest-validate "^20.0.3"
+    leven "^2.1.0"
+    mkdirp "^0.5.1"
+
+jest-validate@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-20.0.3.tgz#d0cfd1de4f579f298484925c280f8f1d94ec3cab"
+  dependencies:
+    chalk "^1.1.3"
+    jest-matcher-utils "^20.0.3"
+    leven "^2.1.0"
+    pretty-format "^20.0.3"
+
+jest@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-20.0.3.tgz#e4fd054c4f1170a116a00761da4cfdb73f1cdc33"
+  dependencies:
+    jest-cli "^20.0.3"
+
 jodid25519@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/jodid25519/-/jodid25519-1.0.2.tgz#06d4912255093419477d425633606e0e90782967"
@@ -1205,9 +1891,66 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
+js-yaml@^3.7.0:
+  version "3.8.4"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^3.1.1"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+
+jsdom@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-10.1.0.tgz#7765e00fd5c3567f34985a1c86ff466a61dacc6a"
+  dependencies:
+    abab "^1.0.3"
+    acorn "^4.0.4"
+    acorn-globals "^3.1.0"
+    array-equal "^1.0.0"
+    content-type-parser "^1.0.1"
+    cssom ">= 0.3.2 < 0.4.0"
+    cssstyle ">= 0.2.37 < 0.3.0"
+    escodegen "^1.6.1"
+    html-encoding-sniffer "^1.0.1"
+    nwmatcher ">= 1.3.9 < 2.0.0"
+    parse5 "^1.5.1"
+    pn "^1.0.0"
+    request "^2.79.0"
+    request-promise-native "^1.0.3"
+    sax "^1.2.1"
+    symbol-tree "^3.2.1"
+    tough-cookie "^2.3.2"
+    webidl-conversions "^4.0.0"
+    whatwg-encoding "^1.0.1"
+    whatwg-url "^4.3.0"
+    xml-name-validator "^2.0.1"
+
+jsdom@^9.12.0:
+  version "9.12.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.12.0.tgz#e8c546fffcb06c00d4833ca84410fed7f8a097d4"
+  dependencies:
+    abab "^1.0.3"
+    acorn "^4.0.4"
+    acorn-globals "^3.1.0"
+    array-equal "^1.0.0"
+    content-type-parser "^1.0.1"
+    cssom ">= 0.3.2 < 0.4.0"
+    cssstyle ">= 0.2.37 < 0.3.0"
+    escodegen "^1.6.1"
+    html-encoding-sniffer "^1.0.1"
+    nwmatcher ">= 1.3.9 < 2.0.0"
+    parse5 "^1.5.1"
+    request "^2.79.0"
+    sax "^1.2.1"
+    symbol-tree "^3.2.1"
+    tough-cookie "^2.3.2"
+    webidl-conversions "^4.0.0"
+    whatwg-encoding "^1.0.1"
+    whatwg-url "^4.3.0"
+    xml-name-validator "^2.0.1"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -1264,6 +2007,17 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+leven@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
+
+levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -1295,9 +2049,68 @@ loader-utils@^1.0.2:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
 
-lodash@^4.14.0, lodash@^4.2.0:
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
+lodash.assignin@^4.0.9:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
+
+lodash.bind@^4.1.4:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
+
+lodash.defaults@^4.0.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+
+lodash.filter@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
+
+lodash.flatten@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+
+lodash.foreach@^4.3.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+
+lodash.map@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
+
+lodash.merge@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
+
+lodash.pick@^4.2.1:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+
+lodash.reduce@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
+
+lodash.reject@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
+
+lodash.some@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
+
+lodash@^4.13.1, lodash@^4.14.0, lodash@^4.16.3, lodash@^4.17.2, lodash@^4.2.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -1309,6 +2122,12 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   dependencies:
     js-tokens "^3.0.0"
 
+makeerror@1.0.x:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
+  dependencies:
+    tmpl "1.0.x"
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -1316,7 +2135,11 @@ memory-fs@^0.4.0, memory-fs@~0.4.1:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
-micromatch@^2.1.5:
+merge@^1.1.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
+
+micromatch@^2.1.5, micromatch@^2.3.11:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
   dependencies:
@@ -1359,17 +2182,17 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -1387,12 +2210,24 @@ nan@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
 
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
 node-fetch@^1.0.1:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-int64@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
 node-libs-browser@^2.0.0:
   version "2.0.0"
@@ -1421,6 +2256,15 @@ node-libs-browser@^2.0.0:
     url "^0.11.0"
     util "^0.10.3"
     vm-browserify "0.0.4"
+
+node-notifier@^5.0.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.1.2.tgz#2fa9e12605fa10009d44549d6fcd8a63dde0e4ff"
+  dependencies:
+    growly "^1.3.0"
+    semver "^5.3.0"
+    shellwords "^0.1.0"
+    which "^1.2.12"
 
 node-pre-gyp@^0.6.29:
   version "0.6.34"
@@ -1467,9 +2311,19 @@ npmlog@^4.0.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
+nth-check@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
+  dependencies:
+    boolbase "~1.0.0"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+
+"nwmatcher@>= 1.3.9 < 2.0.0":
+  version "1.3.9"
+  resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.3.9.tgz#8bab486ff7fa3dfd086656bbe8b17116d3692d2a"
 
 oauth-sign@~0.8.1:
   version "0.8.2"
@@ -1479,6 +2333,31 @@ object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+object-is@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
+
+object-keys@^1.0.10, object-keys@^1.0.8:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object.assign@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.0.4.tgz#b1c9cc044ef1b9fe63606fc141abbb32e14730cc"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.0"
+    object-keys "^1.0.10"
+
+object.entries@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
+
 object.omit@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
@@ -1486,11 +2365,38 @@ object.omit@^2.0.0:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
 
-once@^1.3.0, once@^1.3.3:
+object.values@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.0.4.tgz#e524da09b4f66ff05df457546ec72ac99f13069a"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
+
+once@^1.3.0, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
+
+optimist@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
+  dependencies:
+    minimist "~0.0.1"
+    wordwrap "~0.0.2"
+
+optionator@^0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.4"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    wordwrap "~1.0.0"
 
 os-browserify@^0.2.0:
   version "0.2.1"
@@ -1516,6 +2422,20 @@ osenv@^0.1.4:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+p-limit@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  dependencies:
+    p-limit "^1.1.0"
+
+p-map@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.1.1.tgz#05f5e4ae97a068371bc2a5cc86bfbdbc19c4ae7a"
 
 pako@~0.2.0:
   version "0.2.9"
@@ -1546,6 +2466,10 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse5@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
+
 path-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
@@ -1556,9 +2480,23 @@ path-exists@^2.0.0:
   dependencies:
     pinkie-promise "^2.0.0"
 
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -1582,7 +2520,7 @@ performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
 
-pify@^2.0.0:
+pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
@@ -1602,9 +2540,24 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
+pn@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pn/-/pn-1.0.0.tgz#1cf5a30b0d806cd18f88fc41a6b5d4ad615b3ba9"
+
+prelude-ls@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
+pretty-format@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-20.0.3.tgz#020e350a560a1fe1a98dc3beb6ccffb386de8b14"
+  dependencies:
+    ansi-regex "^2.1.1"
+    ansi-styles "^3.0.0"
 
 private@^0.1.6:
   version "0.1.7"
@@ -1624,7 +2577,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.7, prop-types@~15.5.7:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@~15.5.7:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -1693,6 +2646,13 @@ react-dom@^15.5.4:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "~15.5.7"
+
+react-test-renderer@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.5.4.tgz#d4ebb23f613d685ea8f5390109c2d20fbf7c83bc"
+  dependencies:
+    fbjs "^0.8.9"
+    object-assign "^4.1.0"
 
 react@^15.5.4:
   version "15.5.4"
@@ -1768,7 +2728,21 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.81.0:
+request-promise-core@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+  dependencies:
+    lodash "^4.13.1"
+
+request-promise-native@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.4.tgz#86988ec8eee408e45579fce83bfd05b3adf9a155"
+  dependencies:
+    request-promise-core "1.1.1"
+    stealthy-require "^1.1.0"
+    tough-cookie ">=2.3.0"
+
+request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -1803,6 +2777,16 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+resolve@1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+resolve@^1.3.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
+  dependencies:
+    path-parse "^1.0.5"
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
@@ -1826,6 +2810,26 @@ safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
+
+sane@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/sane/-/sane-1.6.0.tgz#9610c452307a135d29c1fdfe2547034180c46775"
+  dependencies:
+    anymatch "^1.3.0"
+    exec-sh "^0.2.0"
+    fb-watchman "^1.8.0"
+    minimatch "^3.0.2"
+    minimist "^1.1.1"
+    walker "~1.0.5"
+    watch "~0.10.0"
+
+sax@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
+
 "semver@2 || 3 || 4 || 5", semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
@@ -1848,9 +2852,34 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
 
+shellwords@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.0.tgz#66afd47b6a12932d9071cbfd98a52e785cd0ba14"
+
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon-chrome@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/sinon-chrome/-/sinon-chrome-2.2.1.tgz#e02d4709d4e8b2d8582da1612961fa7fa44ce28f"
+  dependencies:
+    lodash "^4.16.3"
+    sinon "^2.1.0"
+    urijs "^1.18.2"
+
+sinon@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.2.0.tgz#3b1b42ff5defcbf51a52a62aca6d61171b9fd262"
+  dependencies:
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lolex "^1.6.0"
+    native-promise-only "^0.8.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -1872,9 +2901,21 @@ source-map-support@^0.4.2:
   dependencies:
     source-map "^0.5.6"
 
+source-map@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
+  dependencies:
+    amdefine ">=0.0.4"
+
 source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+
+source-map@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
+  dependencies:
+    amdefine ">=0.0.4"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -1890,6 +2931,10 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
 sshpk@^1.7.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.0.tgz#ff2a3e4fd04497555fed97b39a0fd82fafb3a33c"
@@ -1904,6 +2949,10 @@ sshpk@^1.7.0:
     jodid25519 "^1.0.0"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+stealthy-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
 stream-browserify@^2.0.1:
   version "2.0.1"
@@ -1921,6 +2970,12 @@ stream-http@^2.3.1:
     readable-stream "^2.2.6"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
+
+string-length@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-1.0.1.tgz#56970fb1c38558e9e70b728bf3de269ac45adfac"
+  dependencies:
+    strip-ansi "^3.0.0"
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
@@ -1950,6 +3005,10 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
+strip-bom@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
@@ -1964,11 +3023,15 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.0:
+supports-color@^3.1.0, supports-color@^3.1.2:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
+
+symbol-tree@^3.2.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
 tapable@^0.2.5, tapable@~0.2.5:
   version "0.2.6"
@@ -1995,11 +3058,33 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+test-exclude@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.1.0.tgz#04ca70b7390dd38c98d4a003a173806ca7991c91"
+  dependencies:
+    arrify "^1.0.1"
+    micromatch "^2.3.11"
+    object-assign "^4.1.0"
+    read-pkg-up "^1.0.1"
+    require-main-filename "^1.0.1"
+
+text-encoding@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
+throat@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-3.0.0.tgz#e7c64c867cbb3845f10877642f7b60055b8ec0d6"
+
 timers-browserify@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.2.tgz#ab4883cf597dcd50af211349a00fbca56ac86b86"
   dependencies:
     setimmediate "^1.0.4"
+
+tmpl@1.0.x:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"
@@ -2009,11 +3094,15 @@ to-fast-properties@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
-tough-cookie@~2.3.0:
+tough-cookie@>=2.3.0, tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
     punycode "^1.4.1"
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
 trim-right@^1.0.1:
   version "1.0.1"
@@ -2033,11 +3122,21 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
+type-check@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  dependencies:
+    prelude-ls "~1.1.2"
+
+type-detect@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
+
 ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
-uglify-js@^2.8.5:
+uglify-js@^2.6, uglify-js@^2.8.5:
   version "2.8.27"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.27.tgz#47787f912b0f242e5b984343be8e35e95f694c9c"
   dependencies:
@@ -2053,6 +3152,10 @@ uglify-to-browserify@~1.0.0:
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+
+urijs@^1.18.2:
+  version "1.18.10"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.18.10.tgz#b94463eaba59a1a796036a467bb633c667f221ab"
 
 url@^0.11.0:
   version "0.11.0"
@@ -2070,6 +3173,10 @@ util@0.10.3, util@^0.10.3:
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   dependencies:
     inherits "2.0.1"
+
+uuid@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
 uuid@^3.0.0:
   version "3.0.1"
@@ -2094,6 +3201,16 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
+walker@~1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
+  dependencies:
+    makeerror "1.0.x"
+
+watch@~0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/watch/-/watch-0.10.0.tgz#77798b2da0f9910d595f1ace5b0c2258521f21dc"
+
 watchpack@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.3.1.tgz#7d8693907b28ce6013e7f3610aa2a1acf07dad87"
@@ -2101,6 +3218,14 @@ watchpack@^1.3.1:
     async "^2.1.2"
     chokidar "^1.4.3"
     graceful-fs "^4.1.2"
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+
+webidl-conversions@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.1.tgz#8015a17ab83e7e1b311638486ace81da6ce206a0"
 
 webpack-sources@^0.2.3:
   version "0.2.3"
@@ -2135,13 +3260,32 @@ webpack@^2.5.1:
     webpack-sources "^0.2.3"
     yargs "^6.0.0"
 
+whatwg-encoding@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz#3c6c451a198ee7aec55b1ec61d0920c67801a5f4"
+  dependencies:
+    iconv-lite "0.4.13"
+
 whatwg-fetch@>=0.10.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
+whatwg-url@^4.3.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.8.0.tgz#d2981aa9148c1e00a41c5a6131166ab4683bbcc0"
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
+
 which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
+
+which@^1.2.12:
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
+  dependencies:
+    isexe "^2.0.0"
 
 wide-align@^1.1.0:
   version "1.1.2"
@@ -2153,9 +3297,20 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
-wordwrap@0.0.2:
+wordwrap@0.0.2, wordwrap@~0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
+
+wordwrap@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+
+worker-farm@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.3.1.tgz#4333112bb49b17aa050b87895ca6b2cacf40e5ff"
+  dependencies:
+    errno ">=0.1.1 <0.2.0-0"
+    xtend ">=4.0.0 <4.1.0-0"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"
@@ -2168,7 +3323,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-xtend@^4.0.0:
+xml-name-validator@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
+
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
@@ -2179,6 +3338,12 @@ y18n@^3.2.1:
 yargs-parser@^4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
+  dependencies:
+    camelcase "^3.0.0"
+
+yargs-parser@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
   dependencies:
     camelcase "^3.0.0"
 
@@ -2199,6 +3364,24 @@ yargs@^6.0.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^4.2.0"
+
+yargs@^7.0.2:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-7.1.0.tgz#6ba318eb16961727f5d284f8ea003e8d6154d0c8"
+  dependencies:
+    camelcase "^3.0.0"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    os-locale "^1.4.0"
+    read-pkg-up "^1.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^1.0.2"
+    which-module "^1.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^5.0.0"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
We can now test the extension with jest! We use enzyme + jsdom to render the components and test their properties.

This PR adds tests for:

* creating tabs
* moving tabs
* removing tabs
* updating tabs
* filtering tabs
* select all

This does not test the gathering of tabs since that would be more mocks than actual tests. The sinon-chrome package is just a set of stubbed out functions and doesn't actually do anything when you call, e.g., `browser.tabs.move`.

Issues fixed:

* rendered tabinfo would not lose favicon when tab lost favicon (e.g., navigating to page without one)
* tab URLs now update
* filtering is now case insensitive (#15)
* newly created tabs weren't filtered
* updated tabs weren't filtered

Tests can be run (after running `yarn` to bring in the dependencies) by running `yarn run jest`.