### PR TITLE
Pin tabs

### DIFF
--- a/src/js/components/sidebar.jsx
+++ b/src/js/components/sidebar.jsx
@@ -283,6 +283,13 @@ export default class SideBar extends React.Component {
 
     const tabInfo = this.state.tabsById.get(tabId);
 
+    // When attaching a tab to a window
+    // updated can be called before
+    // _onTabAttached was called.
+    if (tabInfo == undefined) {
+      return;
+    }
+
     let changed = false;
     for (const key of ["favIconUrl", "title", "url", "pinned"]) {
       if (changeInfo.hasOwnProperty(key)) {

--- a/src/js/components/tabInfo.jsx
+++ b/src/js/components/tabInfo.jsx
@@ -8,10 +8,18 @@ import React from "react";
  * for the tab as well.
  */
 const TabInfo = function TabInfo(props) {
-  const { active, onClick, onSelectionChanged, tabInfo } = props;
+  const {
+    active,
+    onClick,
+    onSelectionChanged,
+    tabInfo,
+    pinned,
+  } = props;
   const { favIconUrl, id, selected, title } = tabInfo;
 
-  const className = active ? "active" : null;
+  const activeClassName = active ? "active" : "";
+  const pinnedClassName = pinned ? "pinned" : "";
+  const className = `${activeClassName} ${pinnedClassName}`;
 
   return (
     <li className={className} onClick={e => onClick(e, id)}>

--- a/src/sidebar.css
+++ b/src/sidebar.css
@@ -25,6 +25,8 @@ body {
   display: flex;
   flex-direction: row;
   align-items: center;
+
+  -moz-user-select: none;
 }
 
 #controls {
@@ -81,4 +83,19 @@ li.active > label {
 #moreActions {
   width: 100%;
   margin-top: 5px;
+}
+
+
+.pinned {
+  font-style: italic;
+}
+
+li.pinned + li:not(.pinned) {
+  margin-top: 10px;
+}
+
+#pinInfo {
+  text-transform: uppercase;
+  color: grey;
+  font-size: 80%;
 }


### PR DESCRIPTION
#5 : Pinned tabs are styled differently and are seperated from other tabs. If pinned tabs are selected, the close and gather buttons are disabled.

![screenshot](https://user-images.githubusercontent.com/19374350/28811630-cd6bec6c-7690-11e7-9671-7db99e622b5d.png)

#11 : With the "(Un)Pin" button, tabs can be pinned or unpinned.

#28 (partial): "select by click" renamed to "select by clicking on tabs"

When all tabs are selected by clicking on their checkboxes, "Select all tabs" is also checked.

Applied `user-select: none` to the tab list, to prevent that double clicking selects the label text.