### PR TITLE
Discarding tabs

### DIFF
--- a/src/js/components/sidebar.jsx
+++ b/src/js/components/sidebar.jsx
@@ -462,7 +462,9 @@ export default class SideBar extends React.Component {
   _discardSelected() {
     const selectedTabIds = this._getSelectedTabIds();
 
-    browser.tabs.discard(selectedTabIds);
+    if (typeof browser.tabs.discard === "function") {
+      browser.tabs.discard(selectedTabIds);
+    }
   }
 
   _pinSelected() {

--- a/src/js/components/sidebar.jsx
+++ b/src/js/components/sidebar.jsx
@@ -37,6 +37,7 @@ export default class SideBar extends React.Component {
     this._gatherSelected = this._gatherSelected.bind(this);
     this._hasPinnedTabs = this._hasPinnedTabs.bind(this);
     this._closeSelected = this._closeSelected.bind(this);
+    this._discardSelected = this._discardSelected.bind(this);
     this._reloadSelected = this._reloadSelected.bind(this);
     this._pinSelected = this._pinSelected.bind(this);
     this._moveSelectedToNewWindow = this._moveSelectedToNewWindow.bind(this);
@@ -68,6 +69,7 @@ export default class SideBar extends React.Component {
         title: tab.title,
         url: tab.url,
         pinned: tab.pinned,
+        discarded: tab.discarded,
       });
 
       if (tab.active) {
@@ -167,6 +169,9 @@ export default class SideBar extends React.Component {
             <button id="pin" onClick={() => this._pinSelected()}>
               (Un)Pin
             </button>
+            <button id="discard" onClick={() => this._discardSelected()}>
+              Discard
+            </button>
           </div>
         </div>
         <div id="content">
@@ -233,6 +238,7 @@ export default class SideBar extends React.Component {
       title: tab.title,
       url: tab.url,
       pinned: tab.pinned,
+      discarded: tab.discarded
     });
 
     tabIds.splice(tab.index, 0, tab.id);
@@ -291,7 +297,7 @@ export default class SideBar extends React.Component {
     }
 
     let changed = false;
-    for (const key of ["favIconUrl", "title", "url", "pinned"]) {
+    for (const key of ["favIconUrl", "title", "url", "pinned", "discarded"]) {
       if (changeInfo.hasOwnProperty(key)) {
         changed = true;
         tabInfo[key] = changeInfo[key];
@@ -451,6 +457,12 @@ export default class SideBar extends React.Component {
     for (const id of selectedTabIds) {
       browser.tabs.reload(id);
     }
+  }
+
+  _discardSelected() {
+    const selectedTabIds = this._getSelectedTabIds();
+
+    browser.tabs.discard(selectedTabIds);
   }
 
   _pinSelected() {

--- a/src/js/components/tabInfo.jsx
+++ b/src/js/components/tabInfo.jsx
@@ -15,11 +15,12 @@ const TabInfo = function TabInfo(props) {
     tabInfo,
     pinned,
   } = props;
-  const { favIconUrl, id, selected, title } = tabInfo;
+  const { favIconUrl, id, selected, title, discarded } = tabInfo;
 
   const activeClassName = active ? "active" : "";
   const pinnedClassName = pinned ? "pinned" : "";
-  const className = `${activeClassName} ${pinnedClassName}`;
+  const discardedClassName = discarded ? "discarded" : "";
+  const className = `${activeClassName} ${pinnedClassName} ${discardedClassName}`;
 
   return (
     <li className={className} onClick={e => onClick(e, id)}>
@@ -30,7 +31,7 @@ const TabInfo = function TabInfo(props) {
           onChange={e => onSelectionChanged(e, id)}
         />
         <img className="favicon" src={favIconUrl} />
-        {title}
+        <span>{title}</span>
       </label>
     </li>
   );

--- a/src/sidebar.css
+++ b/src/sidebar.css
@@ -68,6 +68,7 @@ li.active > label {
 #filter {
   width: 100%;
   margin: 5px 0;
+  box-sizing: border-box;
 }
 
 #content {

--- a/src/sidebar.css
+++ b/src/sidebar.css
@@ -91,6 +91,19 @@ li.active > label {
   font-style: italic;
 }
 
+.discarded {
+  text-decoration: underline;
+  font-style: italic;
+}
+
+.discarded > label > span:before {
+  content: "(";
+}
+
+.discarded > label > span:after {
+  content: ")";
+}
+
 li.pinned + li:not(.pinned) {
   margin-top: 10px;
 }


### PR DESCRIPTION
- See #31, Add ability to discard tabs @mikeconley.
- Bug Fix: The filter textbox did overlap to the right, because of `width: 100%` with border.